### PR TITLE
Added options to enable user to create pipeline policies for their specific api/method.

### DIFF
--- a/src/Demolite.Http/Demolite.Http/Builder/AbstractHttpStatusCodePolicyBuilder.cs
+++ b/src/Demolite.Http/Demolite.Http/Builder/AbstractHttpStatusCodePolicyBuilder.cs
@@ -1,0 +1,74 @@
+﻿using System.Net;
+using Demolite.Http.Common;
+using Demolite.Http.Interfaces;
+
+namespace Demolite.Http.Builder;
+
+public abstract class AbstractHttpStatusCodePolicyBuilder : IHttpStatusCodePolicyBuilder
+{
+    private readonly List<int> _retryCodes = [];
+
+    private readonly List<int> _nonRetryCodes = [];
+
+
+    public virtual IHttpStatusCodePolicyBuilder WithCustomRetryCodes(params HttpStatusCode[] retryCodes)
+    {
+        foreach (var retryCode in retryCodes)
+        {
+            _retryCodes.Add((int)retryCode);
+        }
+
+        return this;
+    }
+
+    public virtual IHttpStatusCodePolicyBuilder WithCustomNonRetryCodes(params HttpStatusCode[] nonRetryCodes)
+    {
+        foreach (var nonRetryCode in nonRetryCodes)
+        {
+            _retryCodes.Add((int)nonRetryCode);
+        }
+
+        return this;
+    }
+
+    public virtual IHttpStatusCodePolicyBuilder WithTooManyRequests()
+    {
+        _retryCodes.Add((int)HttpStatusCode.TooManyRequests);
+        return this;
+    }
+
+    public virtual IHttpStatusCodePolicyBuilder WithServerErrors()
+    {
+        _retryCodes.Add((int)HttpStatusCode.InternalServerError);
+        _retryCodes.Add((int)HttpStatusCode.BadGateway);
+        _retryCodes.Add((int)HttpStatusCode.ServiceUnavailable);
+        _retryCodes.Add((int)HttpStatusCode.GatewayTimeout);
+        return this;
+    }
+
+    public virtual IHttpStatusCodePolicyBuilder WithTimeouts()
+    {
+        _retryCodes.Add((int)HttpStatusCode.RequestTimeout);
+        return this;
+    }
+
+    public virtual IHttpStatusCodePolicyBuilder ExcludeUnauthorized()
+    {
+        _nonRetryCodes.Add((int)HttpStatusCode.Unauthorized);
+        return this;
+    }
+
+    public virtual IHttpStatusCodePolicyBuilder ExcludeNotFound()
+    {
+        _nonRetryCodes.Add((int)HttpStatusCode.NotFound);
+        return this;
+    }
+
+    public virtual IHttpStatusCodePolicyBuilder ExcludeBadRequest()
+    {
+        _nonRetryCodes.Add((int)HttpStatusCode.BadRequest);
+        return this;
+    }
+
+    public HttpStatusCodePolicy Build() => new(_retryCodes, _nonRetryCodes);
+}

--- a/src/Demolite.Http/Demolite.Http/Builder/AbstractResiliencePipelineBuilder.cs
+++ b/src/Demolite.Http/Demolite.Http/Builder/AbstractResiliencePipelineBuilder.cs
@@ -1,0 +1,160 @@
+﻿using System.Net;
+using Demolite.Http.Common;
+using Demolite.Http.Interfaces;
+using Flurl.Http;
+using Polly;
+using Polly.CircuitBreaker;
+using Polly.Retry;
+using Polly.Timeout;
+using Serilog;
+
+namespace Demolite.Http.Builder;
+
+/// <summary>
+/// Abstract implementation of the IResiliencePipelineBuilder interface
+/// </summary>
+public abstract class AbstractResiliencePipelineBuilder : IResiliencePipelineBuilder
+{
+    private readonly ResiliencePipelineBuilder<IFlurlResponse> _pipelineBuilder = new();
+
+    /// <summary>
+    /// StatusCode Policy builder.
+    /// Can be set null if not intended to be used.
+    /// </summary>
+    protected abstract IHttpStatusCodePolicyBuilder IHttpStatusCodePolicyBuilder { get; }
+
+    public virtual IResiliencePipelineBuilder ForGetRequests<TD>() where TD : class
+        => DefaultPipeline<IHttpResponse<TD>>();
+
+    public virtual IResiliencePipelineBuilder ForPostRequests<TD>() where TD : class
+        => DefaultPipeline<TD>();
+
+    public virtual IResiliencePipelineBuilder ForPutRequests<TD>() where TD : class
+        => DefaultPipeline<TD>();
+
+    public virtual IResiliencePipelineBuilder ForDeleteRequests<TD>() where TD : class
+        => DefaultPipeline<TD>();
+
+    public virtual IResiliencePipelineBuilder ForPatchRequests<TD>() where TD : class
+        => DefaultPipeline<TD>();
+
+    public ResiliencePipeline<IFlurlResponse> Build()
+    {
+        return _pipelineBuilder.Build();
+    }
+
+    protected abstract IResiliencePipelineBuilder DefaultPipeline<TD>()
+        where TD : class;
+
+    /// <summary>
+    /// Adds a retry strategy to pipeline.
+    /// </summary>
+    /// <param name="retryAttempts">Amount of times to retry</param>
+    /// <param name="delayBackoffType">Backoff type for the delay</param>
+    /// <param name="delay">Delay (Time) until next retry</param>
+    /// <param name="statusCodePolicy">Which StatusCodes are valid/not valid for retry</param>
+    /// <typeparam name="T">ResponseModel Type</typeparam>
+    protected IResiliencePipelineBuilder WithRetry<T>(
+        int retryAttempts,
+        DelayBackoffType? delayBackoffType = null,
+        TimeSpan? delay = null,
+        HttpStatusCodePolicy? statusCodePolicy = null)
+    {
+        var retryOptions = new RetryStrategyOptions<IFlurlResponse>
+        {
+            ShouldHandle = new PredicateBuilder<IFlurlResponse>().HandleResult(res =>
+                statusCodePolicy?.ShouldRetry(res.StatusCode) ?? !res.ResponseMessage.IsSuccessStatusCode),
+            MaxRetryAttempts = retryAttempts,
+            Delay = delay ?? TimeSpan.FromMilliseconds(100),
+            BackoffType = delayBackoffType ?? DelayBackoffType.Constant,
+
+            OnRetry = args =>
+            {
+                var typeName = "Unknown";
+
+                if (args.Outcome.Result is IHttpResponse<T> response)
+                {
+                    typeName = response.Object?.GetType().Name ?? typeof(T).Name;
+                }
+
+                Log.Debug("Retry attempt: {AttemptNumber} | Type: {TypeName} | Message: {ExceptionMessage}",
+                    args.AttemptNumber,
+                    typeName,
+                    args.Outcome.Exception?.Message);
+                return default;
+            }
+        };
+
+        _pipelineBuilder.AddRetry(retryOptions);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds timeout of specified time to pipeline.
+    /// </summary>
+    /// <param name="timeout">Time until request should time out</param>
+    /// <returns></returns>
+    protected IResiliencePipelineBuilder WithTimeout(TimeSpan timeout)
+    {
+        var timeoutOptions = new TimeoutStrategyOptions
+        {
+            Timeout = timeout,
+            OnTimeout = args =>
+            {
+                Log.Warning("Request timed out after {Timeout}ms", args.Timeout.TotalMilliseconds);
+                return default;
+            }
+        };
+        _pipelineBuilder.AddTimeout(timeoutOptions);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds circuit breaker strategy to pipeline.
+    /// </summary>
+    /// <param name="failureRatio">The failure to success ratio at which the circuit will break</param>
+    /// <param name="minimumThroughput">Amount of actions that must pass through before circuit breakter takes action</param>
+    /// <param name="samplingDuration">Timeframe within which failure ratios are assessed</param>
+    /// <param name="breakDuration">Duration of open circuit</param>
+    /// <param name="statusCodePolicy">Which StatusCodes are valid/not valid for circuit to break</param>
+    protected IResiliencePipelineBuilder WithCircuitBreaker(
+        double failureRatio = 0.5,
+        int minimumThroughput = 10,
+        TimeSpan? samplingDuration = null,
+        TimeSpan? breakDuration = null,
+        HttpStatusCodePolicy? statusCodePolicy = null)
+    {
+        var circuitBreaker = new CircuitBreakerStrategyOptions<IFlurlResponse>()
+        {
+            ShouldHandle = new PredicateBuilder<IFlurlResponse>().HandleResult(res =>
+                statusCodePolicy?.ShouldRetry(res.StatusCode) ?? !res.ResponseMessage.IsSuccessStatusCode),
+            FailureRatio = failureRatio,
+            MinimumThroughput = minimumThroughput,
+            SamplingDuration = samplingDuration ?? TimeSpan.FromSeconds(30),
+            BreakDuration = breakDuration ?? TimeSpan.FromSeconds(5),
+            OnOpened = args =>
+            {
+                var statusCode = (HttpStatusCode)args.Outcome.Result.StatusCode;
+
+                Log.Warning(
+                    "Breaker logging: Breaking the circuit for {args.BreakDuration.TotalMilliseconds}ms ..due to: {StatusCode} ",
+                    args.BreakDuration.TotalMilliseconds, statusCode);
+                return default;
+            },
+            OnClosed = args =>
+            {
+                Log.Information("Breaker logging: Call OK! Closed the circuit again!");
+                return default;
+            },
+            OnHalfOpened = args =>
+            {
+                Log.Information("Breaker logging: Half-open: Next call is a trial!");
+                return default;
+            }
+        };
+
+        _pipelineBuilder.AddCircuitBreaker(circuitBreaker);
+        return this;
+    }
+}

--- a/src/Demolite.Http/Demolite.Http/Builder/AbstractResiliencePipelineBuilder.cs
+++ b/src/Demolite.Http/Demolite.Http/Builder/AbstractResiliencePipelineBuilder.cs
@@ -21,30 +21,31 @@ public abstract class AbstractResiliencePipelineBuilder : IResiliencePipelineBui
     /// StatusCode Policy builder.
     /// Can be set null if not intended to be used.
     /// </summary>
-    protected abstract IHttpStatusCodePolicyBuilder IHttpStatusCodePolicyBuilder { get; }
+    protected abstract IHttpStatusCodePolicyBuilder HttpStatusCodePolicyBuilder { get; }
 
-    public virtual IResiliencePipelineBuilder ForGetRequests<TD>() where TD : class
-        => DefaultPipeline<IHttpResponse<TD>>();
+    public virtual IResiliencePipelineBuilder ForGetRequests()
+        => DefaultPipeline();
 
-    public virtual IResiliencePipelineBuilder ForPostRequests<TD>() where TD : class
-        => DefaultPipeline<TD>();
+    public virtual IResiliencePipelineBuilder ForPostRequests()
+        => DefaultPipeline();
 
-    public virtual IResiliencePipelineBuilder ForPutRequests<TD>() where TD : class
-        => DefaultPipeline<TD>();
+    public virtual IResiliencePipelineBuilder ForPutRequests()
+        => DefaultPipeline();
 
-    public virtual IResiliencePipelineBuilder ForDeleteRequests<TD>() where TD : class
-        => DefaultPipeline<TD>();
+    public virtual IResiliencePipelineBuilder ForDeleteRequests()
+        => DefaultPipeline();
 
-    public virtual IResiliencePipelineBuilder ForPatchRequests<TD>() where TD : class
-        => DefaultPipeline<TD>();
+    public virtual IResiliencePipelineBuilder ForPatchRequests() 
+        => DefaultPipeline();
+
 
     public ResiliencePipeline<IFlurlResponse> Build()
     {
         return _pipelineBuilder.Build();
     }
 
-    protected abstract IResiliencePipelineBuilder DefaultPipeline<TD>()
-        where TD : class;
+    protected abstract IResiliencePipelineBuilder DefaultPipeline();
+
 
     /// <summary>
     /// Adds a retry strategy to pipeline.

--- a/src/Demolite.Http/Demolite.Http/Common/HttpStatusCodePolicy.cs
+++ b/src/Demolite.Http/Demolite.Http/Common/HttpStatusCodePolicy.cs
@@ -1,0 +1,19 @@
+﻿namespace Demolite.Http.Common;
+
+/// <summary>
+/// HttpStatusCodePolicy
+/// </summary>
+/// <param name="retryCodes"></param>
+/// <param name="nonRetryCodes"></param>
+public class HttpStatusCodePolicy(List<int> retryCodes, List<int> nonRetryCodes)
+{
+    /// <summary>
+    /// Returns true based on policy specified in buider.
+    /// </summary>
+    /// <param name="httpStatusCode"></param>
+    /// <returns></returns>
+    public bool ShouldRetry(int httpStatusCode)
+    {
+        return !nonRetryCodes.Contains(httpStatusCode) && retryCodes.Contains(httpStatusCode);
+    }
+}

--- a/src/Demolite.Http/Demolite.Http/Demolite.Http.csproj
+++ b/src/Demolite.Http/Demolite.Http/Demolite.Http.csproj
@@ -20,6 +20,7 @@
     <ItemGroup>
         <None Include="..\..\..\README.md" Pack="true" PackagePath="\"/>
       <PackageReference Include="Flurl.Http" Version="4.0.2" />
+      <PackageReference Include="Polly" Version="8.4.2" />
       <PackageReference Include="Serilog" Version="4.0.2" />
     </ItemGroup>
 

--- a/src/Demolite.Http/Demolite.Http/Interfaces/IHttpStatusCodePolicyBuilder.cs
+++ b/src/Demolite.Http/Demolite.Http/Interfaces/IHttpStatusCodePolicyBuilder.cs
@@ -1,0 +1,28 @@
+﻿using System.Net;
+using Demolite.Http.Common;
+
+namespace Demolite.Http.Interfaces;
+
+/// <summary>
+/// Interface for HttpStatusCodePolicy Builder
+/// </summary>
+public interface IHttpStatusCodePolicyBuilder
+{
+    public IHttpStatusCodePolicyBuilder WithCustomRetryCodes(params HttpStatusCode[] retryCodes);
+
+    public IHttpStatusCodePolicyBuilder WithCustomNonRetryCodes(params HttpStatusCode[] nonRetryCodes);
+
+    public IHttpStatusCodePolicyBuilder WithTooManyRequests();
+
+    public IHttpStatusCodePolicyBuilder WithServerErrors();
+
+    public IHttpStatusCodePolicyBuilder WithTimeouts();
+
+    public IHttpStatusCodePolicyBuilder ExcludeUnauthorized();
+
+    public IHttpStatusCodePolicyBuilder ExcludeNotFound();
+
+    public IHttpStatusCodePolicyBuilder ExcludeBadRequest();
+
+    public HttpStatusCodePolicy Build();
+}

--- a/src/Demolite.Http/Demolite.Http/Interfaces/IResiliencePipelineBuilder.cs
+++ b/src/Demolite.Http/Demolite.Http/Interfaces/IResiliencePipelineBuilder.cs
@@ -1,0 +1,54 @@
+﻿using Flurl.Http;
+using Polly;
+
+namespace Demolite.Http.Interfaces;
+/// <summary>
+/// Interface for the base Resiliencepipelinebuilder
+/// </summary>
+public interface IResiliencePipelineBuilder
+{
+    /// <summary>
+    /// Preassembles a pipeline for GET requests. 
+    /// If no specific pipeline is implemented, the default pipeline is used
+    /// </summary>
+    /// <typeparam name="TD">Type of response model</typeparam>
+    IResiliencePipelineBuilder ForGetRequests<TD>()
+        where TD : class;
+    
+    /// <summary>
+    /// Preassembles a pipeline for POST requests. 
+    /// If no specific pipeline is implemented, the default pipeline is used
+    /// </summary>
+    /// <typeparam name="TD">Type of response model</typeparam>
+    IResiliencePipelineBuilder ForPostRequests<TD>()
+        where TD : class;
+    
+    /// <summary>
+    /// Preassembles a pipeline for PUT requests. 
+    /// If no specific pipeline is implemented, the default pipeline is used
+    /// </summary>
+    /// <typeparam name="TD">Type of response model</typeparam>
+    IResiliencePipelineBuilder ForPutRequests<TD>()
+        where TD : class;
+    
+    /// <summary>
+    /// Preassembles a pipeline for DELETE requests. 
+    /// If no specific pipeline is implemented, the default pipeline is used
+    /// </summary>
+    /// <typeparam name="TD">Type of response model</typeparam>
+    IResiliencePipelineBuilder ForDeleteRequests<TD>()
+        where TD : class;
+
+    /// <summary>
+    /// Preassembles a pipeline for PATCH requests. 
+    /// If no specific pipeline is implemented, the default pipeline is used
+    /// </summary>
+    /// <typeparam name="TD">Type of response model</typeparam>
+    IResiliencePipelineBuilder ForPatchRequests<TD>()
+        where TD : class;
+
+    /// <summary>
+    /// Assembles and returns a pipeline of Type IFlurlResponse
+    /// </summary>
+    ResiliencePipeline<IFlurlResponse> Build();
+}

--- a/src/Demolite.Http/Demolite.Http/Interfaces/IResiliencePipelineBuilder.cs
+++ b/src/Demolite.Http/Demolite.Http/Interfaces/IResiliencePipelineBuilder.cs
@@ -11,41 +11,32 @@ public interface IResiliencePipelineBuilder
     /// Preassembles a pipeline for GET requests. 
     /// If no specific pipeline is implemented, the default pipeline is used
     /// </summary>
-    /// <typeparam name="TD">Type of response model</typeparam>
-    IResiliencePipelineBuilder ForGetRequests<TD>()
-        where TD : class;
+    IResiliencePipelineBuilder ForGetRequests();
     
     /// <summary>
     /// Preassembles a pipeline for POST requests. 
     /// If no specific pipeline is implemented, the default pipeline is used
     /// </summary>
-    /// <typeparam name="TD">Type of response model</typeparam>
-    IResiliencePipelineBuilder ForPostRequests<TD>()
-        where TD : class;
+    IResiliencePipelineBuilder ForPostRequests();
     
     /// <summary>
     /// Preassembles a pipeline for PUT requests. 
     /// If no specific pipeline is implemented, the default pipeline is used
     /// </summary>
-    /// <typeparam name="TD">Type of response model</typeparam>
-    IResiliencePipelineBuilder ForPutRequests<TD>()
-        where TD : class;
+    IResiliencePipelineBuilder ForPutRequests();
     
     /// <summary>
     /// Preassembles a pipeline for DELETE requests. 
     /// If no specific pipeline is implemented, the default pipeline is used
     /// </summary>
-    /// <typeparam name="TD">Type of response model</typeparam>
-    IResiliencePipelineBuilder ForDeleteRequests<TD>()
-        where TD : class;
+    IResiliencePipelineBuilder ForDeleteRequests();
+
 
     /// <summary>
     /// Preassembles a pipeline for PATCH requests. 
     /// If no specific pipeline is implemented, the default pipeline is used
     /// </summary>
-    /// <typeparam name="TD">Type of response model</typeparam>
-    IResiliencePipelineBuilder ForPatchRequests<TD>()
-        where TD : class;
+    IResiliencePipelineBuilder ForPatchRequests();
 
     /// <summary>
     /// Assembles and returns a pipeline of Type IFlurlResponse

--- a/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.Methods.cs
+++ b/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.Methods.cs
@@ -25,17 +25,15 @@ public abstract partial class AbstractHttpRepository<TPb>
 	/// <param name="builder">Url builder.</param>
 	/// <param name="formContent">Possible get form content.</param>
 	/// <param name="defaultValue">Default return value.</param>
-	/// <param name="resiliencePipeline">Resilience pipeline</param>
 	/// <typeparam name="TR">Return value type.</typeparam>
 	/// <returns>A <see cref="IHttpResponse{T}" /> containing the deserialized return value, or default if there was an error</returns>
 	protected async Task<IHttpResponse<TR>> Get<TR>(
 		IUrlBuilder<TPb> builder,
-		ResiliencePipeline<IFlurlResponse>? resiliencePipeline = null,
 		TR? formContent = null,
 		TR? defaultValue = default
 	)
 		where TR : class
-		=> await SendRequestInternal(builder, RequestType.Get, formContent, defaultValue, resiliencePipeline);
+		=> await SendRequestInternal(builder, RequestType.Get, formContent, defaultValue);
 
 	/// <summary>
 	///     Executes a POST request.
@@ -43,15 +41,13 @@ public abstract partial class AbstractHttpRepository<TPb>
 	/// <param name="builder">Url builder.</param>
 	/// <param name="data">Data to be serialized and sent.</param>
 	/// <param name="defaultValue">Default return value.</param>
-	/// <param name="resiliencePipeline">Resilience pipeline</param>
 	/// <typeparam name="T">Transmit type.</typeparam>
 	/// <typeparam name="TR">Return type.</typeparam>
 	/// <returns></returns>
 	protected async Task<IHttpResponse<TR>> Post<T, TR>(
 		IUrlBuilder<TPb> builder, 
-		T? data, TR? defaultValue = default, 
-		ResiliencePipeline<IFlurlResponse>? resiliencePipeline = null)
-		=> await SendRequestInternal(builder, RequestType.Post, data, defaultValue, resiliencePipeline);
+		T? data, TR? defaultValue = default)
+		=> await SendRequestInternal(builder, RequestType.Post, data, defaultValue);
 
 	/// <summary>
 	///     Executes a PUT request.
@@ -59,16 +55,14 @@ public abstract partial class AbstractHttpRepository<TPb>
 	/// <param name="builder">Url builder.</param>
 	/// <param name="data">Data to be serialized and sent.</param>
 	/// <param name="defaultValue">Default return value.</param>
-	/// <param name="resiliencePipeline">Resilience pipeline</param>
 	/// <typeparam name="T">Transmit type.</typeparam>
 	/// <typeparam name="TR">Return type.</typeparam>
 	/// <returns></returns>
 	protected async Task<IHttpResponse<TR>> Put<T, TR>(
 		IUrlBuilder<TPb> builder,
 		T? data,
-		TR? defaultValue = default, 
-		ResiliencePipeline<IFlurlResponse>? resiliencePipeline = null)
-		=> await SendRequestInternal(builder, RequestType.Put, data, defaultValue, resiliencePipeline);
+		TR? defaultValue = default)
+		=> await SendRequestInternal(builder, RequestType.Put, data, defaultValue);
 
 	/// <summary>
 	///     Executes a PATCH request.
@@ -76,16 +70,14 @@ public abstract partial class AbstractHttpRepository<TPb>
 	/// <param name="builder">Url builder.</param>
 	/// <param name="data">Data to be serialized and sent.</param>
 	/// <param name="defaultValue">Default return value.</param>
-	/// <param name="resiliencePipeline">Resilience pipeline</param>
 	/// <typeparam name="T">Transmit type.</typeparam>
 	/// <typeparam name="TR">Return type.</typeparam>
 	/// <returns></returns>
 	protected async Task<IHttpResponse<TR>> Patch<T, TR>(
 		IUrlBuilder<TPb> builder, 
 		T? data, 
-		TR? defaultValue = default,
-		ResiliencePipeline<IFlurlResponse>? resiliencePipeline = null)
-		=> await SendRequestInternal(builder, RequestType.Patch, data, defaultValue, resiliencePipeline);
+		TR? defaultValue = default)
+		=> await SendRequestInternal(builder, RequestType.Patch, data, defaultValue);
 
 	/// <summary>
 	///     Method with actually sends the request to the endpoint.
@@ -94,7 +86,6 @@ public abstract partial class AbstractHttpRepository<TPb>
 	/// <param name="requestType"></param>
 	/// <param name="data"></param>
 	/// <param name="defaultValue"></param>
-	/// <param name="resiliencePipeline"></param>
 	/// <typeparam name="T"></typeparam>
 	/// <typeparam name="TR"></typeparam>
 	/// <returns></returns>
@@ -102,15 +93,14 @@ public abstract partial class AbstractHttpRepository<TPb>
 		IFlurlRequest request,
 		RequestType requestType,
 		T? data,
-		TR? defaultValue = default,
-		ResiliencePipeline<IFlurlResponse>? resiliencePipeline = null
+		TR? defaultValue = default
 	)
 	{
 		try
 		{
 			var jsonString = JsonSerializer.Serialize(data, GetOptions());
 			var jsonData = new StringContent(jsonString, Encoding.UTF8, "application/json");
-			var pipeline = resiliencePipeline ?? ResiliencePipeline<IFlurlResponse>.Empty;
+			var pipeline = GetPipeline(requestType);
 
 			var flurlResponse = await pipeline.ExecuteAsync(async token =>
 			{
@@ -142,8 +132,7 @@ public abstract partial class AbstractHttpRepository<TPb>
 		IUrlBuilder<TPb> builder,
 		RequestType requestType,
 		T? data,
-		TR? defaultValue = default,
-		ResiliencePipeline<IFlurlResponse>? resiliencePipeline = null
+		TR? defaultValue = default
 	)
 	{
 		await PrepareRequest();
@@ -176,6 +165,6 @@ public abstract partial class AbstractHttpRepository<TPb>
 				throw new ArgumentOutOfRangeException(nameof(requestType), requestType, null);
 		}
 
-		return await SendRequest(request, requestType, data, defaultValue, resiliencePipeline);
+		return await SendRequest(request, requestType, data, defaultValue);
 	}
 }

--- a/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.Resilience.cs
+++ b/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.Resilience.cs
@@ -1,0 +1,62 @@
+﻿using Demolite.Http.Enum;
+using Demolite.Http.Interfaces;
+using Flurl.Http;
+using Polly;
+
+namespace Demolite.Http.Repository;
+
+public abstract partial class AbstractHttpRepository<TPb>
+{
+    /// <summary>
+    /// Default resilience pipeline builder.
+    /// Can be set null if not intended to be used.
+    /// </summary>
+    protected virtual IResiliencePipelineBuilder? ResiliencePipelineBuilder => null;
+
+    /// <summary>
+    /// Holds pipelines if any are created.
+    /// </summary>
+    protected Dictionary<RequestType, ResiliencePipeline<IFlurlResponse>> ResiliencePipelines = [];
+
+    /// <summary>
+    ///     Setup method used to prepare the Flurl Client
+    /// </summary>
+    protected abstract void SetupClient();
+
+    /// <summary>
+    /// Setup method to create ResiliencePipelines dictionary.
+    /// If a ResiliencePipelineBuilder, it will create the pipelines for the respective request type.
+    /// Returns an empty dictionary if ResiliencePipelineBuilder is null. 
+    /// </summary>
+    protected virtual void SetupPipelines()
+    {
+        if (ResiliencePipelineBuilder == null) return;
+
+        var getPipeline = ResiliencePipelineBuilder.ForGetRequests().Build();
+        ResiliencePipelines.Add(RequestType.Get, getPipeline);
+
+        var putPipeline = ResiliencePipelineBuilder.ForPutRequests().Build();
+        ResiliencePipelines.Add(RequestType.Put, putPipeline);
+
+        var patchPipeline = ResiliencePipelineBuilder.ForPatchRequests().Build();
+        ResiliencePipelines.Add(RequestType.Patch, patchPipeline);
+
+        var deletePipeline = ResiliencePipelineBuilder.ForDeleteRequests().Build();
+        ResiliencePipelines.Add(RequestType.Delete, deletePipeline);
+
+        var postPipeline = ResiliencePipelineBuilder.ForPostRequests().Build();
+        ResiliencePipelines.Add(RequestType.Post, postPipeline);
+    }
+
+    /// <summary>
+    /// Returns the request type specific pipeline or an empty pipeline. 
+    /// </summary>
+    /// <param name="requestType"></param>
+    /// <returns></returns>
+    protected ResiliencePipeline<IFlurlResponse> GetPipeline(RequestType requestType)
+    {
+        return ResiliencePipelines.TryGetValue(requestType, out var pipeline)
+            ? pipeline
+            : ResiliencePipeline<IFlurlResponse>.Empty;
+    }
+}

--- a/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.cs
+++ b/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Demolite.Http.Interfaces;
 using Flurl.Http;
+using Polly;
 
 namespace Demolite.Http.Repository;
 
@@ -18,6 +19,12 @@ public abstract partial class AbstractHttpRepository<TPb>
 	///     Default request timeout in milliseconds.
 	/// </summary>
 	protected virtual int Timeout => 5000;
+	
+	/// <summary>
+	/// Default resilience pipeline builder.
+	/// Can be set null if not intended to be used.
+	/// </summary>
+	protected virtual IResiliencePipelineBuilder? ResiliencePipelineBuilder { get; }
 
 	/// <summary>
 	///     Setup method used to prepare the Flurl Client

--- a/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.cs
+++ b/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.cs
@@ -21,61 +21,8 @@ public abstract partial class AbstractHttpRepository<TPb>
 	///     Default request timeout in milliseconds.
 	/// </summary>
 	protected virtual int Timeout => 5000;
-	
-	/// <summary>
-	/// Default resilience pipeline builder.
-	/// Can be set null if not intended to be used.
-	/// </summary>
-	protected virtual IResiliencePipelineBuilder? ResiliencePipelineBuilder => null;
-	
-	/// <summary>
-	/// Holds pipelines if any are created.
-	/// </summary>
-	protected Dictionary<RequestType, ResiliencePipeline<IFlurlResponse>> ResiliencePipelines;
 
 
-	/// <summary>
-	///     Setup method used to prepare the Flurl Client
-	/// </summary>
-	protected abstract void SetupClient();
-
-	/// <summary>
-	/// Setup method to create ResiliencePipelines dictionary.
-	/// If a ResiliencePipelineBuilder, it will create the pipelines for the respective request type.
-	/// Returns an empty dictionary if ResiliencePipelineBuilder is null. 
-	/// </summary>
-	protected virtual void SetupPipelines()
-	{
-		ResiliencePipelines = new();
-		if (ResiliencePipelineBuilder == null) return;
-		
-		var getPipeline = ResiliencePipelineBuilder.ForGetRequests().Build();
-		ResiliencePipelines.Add(RequestType.Get, getPipeline);
-		
-		var putPipeline = ResiliencePipelineBuilder.ForPutRequests().Build();
-		ResiliencePipelines.Add(RequestType.Put, putPipeline);
-		
-		var patchPipeline = ResiliencePipelineBuilder.ForPatchRequests().Build();
-		ResiliencePipelines.Add(RequestType.Patch, patchPipeline);
-		
-		var deletePipeline = ResiliencePipelineBuilder.ForDeleteRequests().Build();
-		ResiliencePipelines.Add(RequestType.Delete, deletePipeline);
-		
-		var postPipeline = ResiliencePipelineBuilder.ForPostRequests().Build();
-		ResiliencePipelines.Add(RequestType.Post, postPipeline);
-	}
-
-	/// <summary>
-	/// Returns the request type specific pipeline or an empty pipeline. 
-	/// </summary>
-	/// <param name="requestType"></param>
-	/// <returns></returns>
-	protected ResiliencePipeline<IFlurlResponse> GetPipeline(RequestType requestType)
-	{
-		return ResiliencePipelines.TryGetValue(requestType, out var pipeline)
-			? pipeline : ResiliencePipeline<IFlurlResponse>.Empty;
-	}
-	
 	/// <summary>
 	///     Creates the base request.
 	/// </summary>

--- a/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.cs
+++ b/src/Demolite.Http/Demolite.Http/Repository/AbstractHttpRepository.cs
@@ -1,4 +1,5 @@
-﻿using Demolite.Http.Interfaces;
+﻿using Demolite.Http.Enum;
+using Demolite.Http.Interfaces;
 using Flurl.Http;
 using Polly;
 
@@ -13,6 +14,7 @@ public abstract partial class AbstractHttpRepository<TPb>
 	protected AbstractHttpRepository()
 	{
 		SetupClient();
+		SetupPipelines();
 	}
 
 	/// <summary>
@@ -24,13 +26,56 @@ public abstract partial class AbstractHttpRepository<TPb>
 	/// Default resilience pipeline builder.
 	/// Can be set null if not intended to be used.
 	/// </summary>
-	protected virtual IResiliencePipelineBuilder? ResiliencePipelineBuilder { get; }
+	protected virtual IResiliencePipelineBuilder? ResiliencePipelineBuilder => null;
+	
+	/// <summary>
+	/// Holds pipelines if any are created.
+	/// </summary>
+	protected Dictionary<RequestType, ResiliencePipeline<IFlurlResponse>> ResiliencePipelines;
+
 
 	/// <summary>
 	///     Setup method used to prepare the Flurl Client
 	/// </summary>
 	protected abstract void SetupClient();
 
+	/// <summary>
+	/// Setup method to create ResiliencePipelines dictionary.
+	/// If a ResiliencePipelineBuilder, it will create the pipelines for the respective request type.
+	/// Returns an empty dictionary if ResiliencePipelineBuilder is null. 
+	/// </summary>
+	protected virtual void SetupPipelines()
+	{
+		ResiliencePipelines = new();
+		if (ResiliencePipelineBuilder == null) return;
+		
+		var getPipeline = ResiliencePipelineBuilder.ForGetRequests().Build();
+		ResiliencePipelines.Add(RequestType.Get, getPipeline);
+		
+		var putPipeline = ResiliencePipelineBuilder.ForPutRequests().Build();
+		ResiliencePipelines.Add(RequestType.Put, putPipeline);
+		
+		var patchPipeline = ResiliencePipelineBuilder.ForPatchRequests().Build();
+		ResiliencePipelines.Add(RequestType.Patch, patchPipeline);
+		
+		var deletePipeline = ResiliencePipelineBuilder.ForDeleteRequests().Build();
+		ResiliencePipelines.Add(RequestType.Delete, deletePipeline);
+		
+		var postPipeline = ResiliencePipelineBuilder.ForPostRequests().Build();
+		ResiliencePipelines.Add(RequestType.Post, postPipeline);
+	}
+
+	/// <summary>
+	/// Returns the request type specific pipeline or an empty pipeline. 
+	/// </summary>
+	/// <param name="requestType"></param>
+	/// <returns></returns>
+	protected ResiliencePipeline<IFlurlResponse> GetPipeline(RequestType requestType)
+	{
+		return ResiliencePipelines.TryGetValue(requestType, out var pipeline)
+			? pipeline : ResiliencePipeline<IFlurlResponse>.Empty;
+	}
+	
 	/// <summary>
 	///     Creates the base request.
 	/// </summary>


### PR DESCRIPTION
This addition to the package allows the user to specify API and method specific pipeline that can be built and passed along as an argument. Implementing this is entirely optional, and choosing not to do so will not affect the current usage. 

Example usage: 

``` 
public class MyResiliencePipelineBuilder : AbstractResiliencePipelineBuilder
{
    protected override IHttpStatusCodePolicyBuilder IHttpStatusCodePolicyBuilder => new MyHttpStatusCodePolicyBuilder();

    public override IResiliencePipelineBuilder ForGetRequests<TD>()
    {
        var retryConfig = IHttpStatusCodePolicyBuilder.ExcludeUnauthorized().WithTooManyRequests().ExcludeBadRequest().Build();
        var breakerConfig = IHttpStatusCodePolicyBuilder.WithServerErrors().WithTimeouts().ExcludeBadRequest().Build();
        WithRetry<TD>(2, statusCodePolicy: retryConfig);
        WithCircuitBreaker(statusCodePolicy: breakerConfig);

        return this;
    }
```

```
public class MyInvoiceRepository(IMyAuthenticationService authenticationService)
    : AbstractMyRepository(authenticationService), IMyRepository
{
    public async Task<IHttpResponse<IMyResponse>> GetById(string id)
    {
            var uri = MyUrlBuilder.Endpoints.Invoice(invoiceId);
            var pipeline = ResiliencePipelineBuilder.ForGetRequests<MyResponse>().Build();
            var result =  await Get<MyResponse>(uri, pipeline);

            return HttpResponse<IMyResponse>.FromResult(result, x => x);
    }
@